### PR TITLE
feat: OAuth 연결 구현 (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+JWT_SECRET=replace-with-your-jwt-secret
+NAVER_CLIENT_ID=replace-with-your-naver-client-id
+NAVER_CLIENT_SECRET=replace-with-your-naver-client-secret

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Local secrets
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/financialinvestment/FinancialInvestmentApplication.java
+++ b/src/main/java/com/financialinvestment/FinancialInvestmentApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication
 public class FinancialInvestmentApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(FinancialInvestmentApplication.class, args);

--- a/src/main/java/com/financialinvestment/domain/auth/entity/OauthProvider.java
+++ b/src/main/java/com/financialinvestment/domain/auth/entity/OauthProvider.java
@@ -1,0 +1,36 @@
+package com.financialinvestment.domain.auth.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthProvider {
+
+    KAKAO("kakao", "카카오"),
+    NAVER("naver","네이버"),
+    GOOGLE("google", "구글");
+
+    private final String code;
+    private final String displayName;
+
+    // 문자열로부터 OAuthProvider 찾기
+    public static OauthProvider fromCode(String code) {
+        for (OauthProvider provider : values()) {
+            if (provider.getCode().equalsIgnoreCase(code)) {
+                return provider;
+            }
+        }
+        throw new IllegalArgumentException("Invalid OAuth provider: " + code);
+    }
+
+    // 문자열이 유효한 OAuth provider인지 확인
+    public static boolean isValid(String code) {
+        try {
+            fromCode(code);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/auth/entity/Role.java
+++ b/src/main/java/com/financialinvestment/domain/auth/entity/Role.java
@@ -1,0 +1,16 @@
+package com.financialinvestment.domain.auth.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/com/financialinvestment/domain/auth/entity/User.java
+++ b/src/main/java/com/financialinvestment/domain/auth/entity/User.java
@@ -1,0 +1,57 @@
+package com.financialinvestment.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"provider", "provider_user_id"})
+        }
+)
+@Getter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OauthProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false, length = 100)
+    private String providerUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdDate = LocalDateTime.now();
+    }
+
+    public User(String name, String email, OauthProvider provider, String providerUserId, Role role) {
+        this.name = name;
+        this.email = email;
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/financialinvestment/domain/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,44 @@
+package com.financialinvestment.domain.auth.handler;
+
+import com.financialinvestment.domain.auth.service.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        Long userId = Long.valueOf(String.valueOf(attributes.get("userId")));
+        String role = String.valueOf(attributes.get("role"));
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userId, role);
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");   // 이게 핵심
+        cookie.setMaxAge(60 * 60); // 1시간
+        response.addCookie(cookie);
+        response.addCookie(cookie);
+        response.sendRedirect("http://localhost:5173/login/success");
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/financialinvestment/domain/auth/handler/OAuth2LoginSuccessHandler.java
@@ -38,7 +38,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         cookie.setPath("/");   // 이게 핵심
         cookie.setMaxAge(60 * 60); // 1시간
         response.addCookie(cookie);
-        response.addCookie(cookie);
         response.sendRedirect("http://localhost:5173/login/success");
     }
 }

--- a/src/main/java/com/financialinvestment/domain/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/financialinvestment/domain/auth/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.financialinvestment.domain.auth.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secret;
+    private long accessTokenExpiration;
+    private long refreshTokenExpiration;
+}

--- a/src/main/java/com/financialinvestment/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/financialinvestment/domain/auth/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.financialinvestment.domain.auth.repository;
+
+import com.financialinvestment.domain.auth.entity.OauthProvider;
+import com.financialinvestment.domain.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByProviderAndProviderUserId(OauthProvider oauthProvider, String providerUserId);
+}
+

--- a/src/main/java/com/financialinvestment/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/financialinvestment/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,74 @@
+package com.financialinvestment.domain.auth.service;
+
+import com.financialinvestment.domain.auth.entity.OauthProvider;
+import com.financialinvestment.domain.auth.entity.Role;
+import com.financialinvestment.domain.auth.entity.User;
+import com.financialinvestment.domain.auth.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+
+
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        String providerUserId = (String) response.get("id");
+        String email = (String) response.get("email");
+        String name = (String) response.get("name");
+
+        System.out.println(registrationId);
+        System.out.println(providerUserId);
+        System.out.println(email);
+        System.out.println(name);
+
+        User user = userRepository
+                .findByProviderAndProviderUserId(OauthProvider.NAVER, providerUserId)
+                .orElseGet(() -> {
+                    User newUser = new User(name, email, OauthProvider.NAVER, providerUserId, Role.USER);
+                    return userRepository.save(newUser);
+                });
+
+        Map<String, Object> customAttributes = new HashMap<>(response);
+        customAttributes.put("userId", user.getUserId());
+        customAttributes.put("role", user.getRole().name());
+        customAttributes.put("name", user.getName());
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),
+                customAttributes,
+                "userId"
+        );
+    }
+
+}

--- a/src/main/java/com/financialinvestment/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/financialinvestment/domain/auth/service/CustomOAuth2UserService.java
@@ -37,9 +37,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
                 .getUserInfoEndpoint().getUserNameAttributeName();
 
-
-
-
         Map<String, Object> attributes = oAuth2User.getAttributes();
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
 
@@ -47,10 +44,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String email = (String) response.get("email");
         String name = (String) response.get("name");
 
-        System.out.println(registrationId);
-        System.out.println(providerUserId);
-        System.out.println(email);
-        System.out.println(name);
+//        System.out.println(registrationId);
+//        System.out.println(providerUserId);
+//        System.out.println(email);
+//        System.out.println(name);
 
         User user = userRepository
                 .findByProviderAndProviderUserId(OauthProvider.NAVER, providerUserId)

--- a/src/main/java/com/financialinvestment/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/financialinvestment/domain/auth/service/JwtTokenProvider.java
@@ -1,0 +1,99 @@
+package com.financialinvestment.domain.auth.service;
+
+import com.financialinvestment.domain.auth.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId, String role) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("role", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    public String extractToken(String bearerToken) {
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/config/SecurityConfig.java
+++ b/src/main/java/com/financialinvestment/domain/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.financialinvestment.domain.config;
+
+import com.financialinvestment.domain.auth.entity.Role;
+import com.financialinvestment.domain.auth.handler.OAuth2LoginSuccessHandler;
+import com.financialinvestment.domain.auth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/",
+                                "/error",
+                                "oauth2/authorization/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+                        .requestMatchers("/api/v1/users/**").hasRole(Role.USER.name())
+                        .requestMatchers("/h2-console/**").hasRole(Role.ADMIN.name())
+//                        .requestMatchers("/api/v1/auth/**").authenticated() //로그인이 되어 있다면
+                        .anyRequest().denyAll() //그 외에는 모두 거부.
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                )
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/")
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                );
+
+        return http.build();
+    }
+
+
+}

--- a/src/main/java/com/financialinvestment/domain/config/SecurityConfig.java
+++ b/src/main/java/com/financialinvestment/domain/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
@@ -24,18 +25,20 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .formLogin((auth) -> auth.disable())
+                .httpBasic((auth) -> auth.disable())
                 .headers(headers -> headers.frameOptions(frame -> frame.disable()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/",
-                                "/error",
-                                "oauth2/authorization/**"
-                        ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
-                        .requestMatchers("/api/v1/users/**").hasRole(Role.USER.name())
-                        .requestMatchers("/h2-console/**").hasRole(Role.ADMIN.name())
+                                .requestMatchers(
+                                        "/",
+                                        "/error",
+                                        "oauth2/authorization/**"
+                                ).permitAll()
+                                .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+                                .requestMatchers("/api/v1/users/**").hasRole(Role.USER.name())
+                                .requestMatchers("/h2-console/**").hasRole(Role.ADMIN.name())
 //                        .requestMatchers("/api/v1/auth/**").authenticated() //로그인이 되어 있다면
-                        .anyRequest().denyAll() //그 외에는 모두 거부.
+                                .anyRequest().denyAll() //그 외에는 모두 거부.
                 )
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
@@ -48,7 +51,9 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
-                );
+                )
+                .sessionManagement((session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)));//세션 설정을 STATELESS방식으로 함.
 
         return http.build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=financial-Investment
-
+spring.config.import=optional:file:.env[.properties]
 
 #?? H2 DB
 spring.datasource.url=jdbc:h2:tcp://localhost/~/test
@@ -11,18 +11,20 @@ spring.jpa.show-sql=true
 spring.h2.console.enabled=true
 
 #jwt ??
-jwt.secret=abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz
+jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration=3600000
 jwt.refresh-token-expiration=604800000
 
-#Oauth??
-spring.security.oauth2.client.registration.naver.client-id=inSUF7hPdvzySgfxczZr
-spring.security.oauth2.client.registration.naver.client-secret=CilzEHc7KJ
-spring.security.oauth2.client.registration.naver.scope=name,email
+#registration
+#?? ????? ?? ????? ???? ?? ??? ???
 spring.security.oauth2.client.registration.naver.client-name=Naver
+spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID}
+spring.security.oauth2.client.registration.naver.client-secret=${NAVER_CLIENT_SECRET}
+spring.security.oauth2.client.registration.naver.scope=name,email
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
 
+#provider ??
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,29 @@
 spring.application.name=financial-Investment
+
+
+#?? H2 DB
+spring.datasource.url=jdbc:h2:tcp://localhost/~/test
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.h2.console.enabled=true
+
+#jwt ??
+jwt.secret=abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz
+jwt.access-token-expiration=3600000
+jwt.refresh-token-expiration=604800000
+
+#Oauth??
+spring.security.oauth2.client.registration.naver.client-id=inSUF7hPdvzySgfxczZr
+spring.security.oauth2.client.registration.naver.client-secret=CilzEHc7KJ
+spring.security.oauth2.client.registration.naver.scope=name,email
+spring.security.oauth2.client.registration.naver.client-name=Naver
+spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
+
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response


### PR DESCRIPTION
  ## 작업 내용
  - Spring Security 기반 OAuth 로그인 흐름을 구성했습니다.
  - OAuth 로그인 성공 시 사용자 정보를 조회하고, DB 사용자와 연결하도록 구현했습니다.
  - 로그인 성공 후 JWT를 생성해 쿠키에 저장하는 처리까지 연결했습니다.
  - H2 콘솔 및 기본 보안 설정을 개발 환경 기준으로 구성했습니다.

  ## 상세 변경 사항
  - `SecurityConfig`에서 OAuth2 로그인 및 인가 규칙 설정
  - `CustomOAuth2UserService`에서 소셜 사용자 정보 수신 및 회원 조회/생성 처리
  - `OAuth2LoginSuccessHandler`에서 JWT 생성 및 쿠키 저장 처리
  - `JwtTokenProvider`에서 JWT 생성/검증 로직 구현
  - `User`, `Role`, `OauthProvider` 등 인증 관련 도메인 구성

  ## 현재 범위
  이번 PR의 범위는 아래까지입니다.
  - OAuth 로그인 진행
  - 소셜 사용자 정보 수신
  - 로그인 성공 후 JWT 생성

  아직 포함되지 않은 범위:
  - JWT 기반 요청 인증 필터
  - JWT를 사용한 로그인 상태 유지
  - 사용자 정보 조회 API
  - refresh token 처리

  ## 확인 사항
  - OAuth 로그인 성공 후 JWT가 생성되는 흐름까지 구현했습니다.
  - 이후 일반 API 요청에서 JWT를 검증하는 필터는 아직 구현되지 않았습니다.