### PR TITLE
feat: 홈페이지 대시보드 차트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/financialinvestment/domain/auth/config/SecurityConfig.java
+++ b/src/main/java/com/financialinvestment/domain/auth/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.financialinvestment.domain.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/stock/market/indexes/summary",
+                                "/stock/market/exchange-rate/summary",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/auth/config/WebConfig.java
+++ b/src/main/java/com/financialinvestment/domain/auth/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.financialinvestment.domain.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/stock/**")
+                .allowedOrigins(
+                        "http://127.0.0.1:5173",
+                        "http://localhost:5173"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false);
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/stock/config/KisClientConfig.java
+++ b/src/main/java/com/financialinvestment/domain/stock/config/KisClientConfig.java
@@ -1,0 +1,23 @@
+package com.financialinvestment.domain.stock.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class KisClientConfig {
+
+    @Bean
+    public RestClient kisRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://openapi.koreainvestment.com:9443")
+                .build();
+    }
+    @Bean
+    public RestClient kisMockRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://openapi.koreainvestment.com:29443")
+                .build();
+    }
+
+}

--- a/src/main/java/com/financialinvestment/domain/stock/controller/StockController.java
+++ b/src/main/java/com/financialinvestment/domain/stock/controller/StockController.java
@@ -1,0 +1,36 @@
+package com.financialinvestment.domain.stock.controller;
+
+
+import com.financialinvestment.domain.stock.dto.front.IndexSummaryResponseDto;
+import com.financialinvestment.domain.stock.service.StockService;
+import com.financialinvestment.domain.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/stock")
+@RequiredArgsConstructor
+@Slf4j
+public class StockController {
+
+    private final StockService stockService;
+
+    @GetMapping("/market/indexes/summary")
+    public ApiResponse<List<IndexSummaryResponseDto>> getIndexSummaries() throws InterruptedException {
+        List<IndexSummaryResponseDto> result = stockService.getIndexSummaries();
+        log.debug("대시보드용 요약 조회함.");
+        return ApiResponse.success("대시보드용 요약 조회 성공", result);
+    }
+
+    @GetMapping("/market/exchange-rate/summary")
+    public ApiResponse<List<IndexSummaryResponseDto>> getExchangeRateSummary() throws InterruptedException {
+        List<IndexSummaryResponseDto> result = stockService.getExchangeRateSummary();
+        return ApiResponse.success("환율 요약 조회 성공", result);
+    }
+
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/front/ExchangeRateResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/front/ExchangeRateResponseDto.java
@@ -1,0 +1,17 @@
+package com.financialinvestment.domain.stock.dto.front;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ExchangeRateResponseDto {
+    private String id;              // usdKrw
+    private String label;           // 원/달러
+    private BigDecimal currentRate; // t_rate
+    private BigDecimal previousRate;// p_rate
+    private OffsetDateTime baseDateTime;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/front/IndexDailyChartPointDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/front/IndexDailyChartPointDto.java
@@ -1,0 +1,14 @@
+package com.financialinvestment.domain.stock.dto.front;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class IndexDailyChartPointDto {
+
+    private String time;          // 영업일자 2026-05-12
+    private BigDecimal value;     // 해당일 지수
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/front/IndexSummaryResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/front/IndexSummaryResponseDto.java
@@ -1,0 +1,25 @@
+package com.financialinvestment.domain.stock.dto.front;
+
+import com.financialinvestment.domain.util.Direction;
+import com.financialinvestment.domain.util.IndexType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class IndexSummaryResponseDto {
+
+    private String id;                    // kospi, kosdaq
+    private String label;                 // 코스피, 코스닥
+    private BigDecimal currentPrice;
+    private BigDecimal change;
+    private BigDecimal changeRate;
+    private Direction direction;
+    private OffsetDateTime baseDateTime;
+    private String chartColor;            // #ba1a1a 등
+    private List<IndexDailyChartPointDto> chartData;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisAccessTokenRequestDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisAccessTokenRequestDto.java
@@ -1,0 +1,12 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KisAccessTokenRequestDto {
+    private String grant_type;
+    private String appkey;
+    private String appsecret;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisAccessTokenResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisAccessTokenResponseDto.java
@@ -1,0 +1,22 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KisAccessTokenResponseDto {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token_token_expired")
+    private String tokenExpired;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexApiResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexApiResponseDto.java
@@ -1,0 +1,26 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class KisDailyIndexApiResponseDto {
+    @JsonProperty("rt_cd")
+    private String rtCd;   // 성공 실패 여부
+
+    @JsonProperty("msg_cd")
+    private String msgCd;  // 응답코드
+
+    @JsonProperty("msg1")
+    private String msg1;   // 응답메시지
+
+    @JsonProperty("output1")
+    private KisDailyIndexOutput1Dto output1;
+
+    @JsonProperty("output2")
+    private List<KisDailyIndexOutput2Dto> output2;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexOutput1Dto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexOutput1Dto.java
@@ -1,0 +1,74 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 현재 해당 dto에서 실제로 사용할 값
+ * 현재가, 전일대비, 등락률, 방향, 거래량, 거래대금
+ */
+@Getter
+@NoArgsConstructor
+public class KisDailyIndexOutput1Dto {
+
+    @JsonProperty("bstp_nmix_prpr")
+    private String bstpNmixPrpr; //지수 현재가
+
+    @JsonProperty("bstp_nmix_prdy_vrss")
+    private String bstpNmixPrdyVrss; //지수 전일 대비
+
+    @JsonProperty("prdy_vrss_sign")
+    private String prdyVrssSign; //전일 대비 부호
+
+    @JsonProperty("bstp_nmix_prdy_ctrt")
+    private String bstpNmixPrdyCtrt; //지수 전일 대비율
+
+    @JsonProperty("acml_vol")
+    private String acmlVol; //누적 거래량
+
+    @JsonProperty("acml_tr_pbmn")
+    private String acmlTrPbmn; //누적 거래 대금
+
+    @JsonProperty("bstp_nmix_oprc")
+    private String bstpNmixOprc;
+
+    @JsonProperty("bstp_nmix_hgpr")
+    private String bstpNmixHgpr;
+
+    @JsonProperty("bstp_nmix_lwpr")
+    private String bstpNmixLwpr;
+
+    @JsonProperty("prdy_vol")
+    private String prdyVol;
+
+    @JsonProperty("ascn_issu_cnt")
+    private String ascnIssuCnt;
+
+    @JsonProperty("down_issu_cnt")
+    private String downIssuCnt;
+
+    @JsonProperty("stnr_issu_cnt")
+    private String stnrIssuCnt;
+
+    @JsonProperty("uplm_issu_cnt")
+    private String uplmIssuCnt;
+
+    @JsonProperty("lslm_issu_cnt")
+    private String lslmIssuCnt;
+
+    @JsonProperty("prdy_tr_pbmn")
+    private String prdyTrPbmn;
+
+    @JsonProperty("dryy_bstp_nmix_hgpr_date")
+    private String dryyBstpNmixHgprDate;
+
+    @JsonProperty("dryy_bstp_nmix_hgpr")
+    private String dryyBstpNmixHgpr;
+
+    @JsonProperty("dryy_bstp_nmix_lwpr")
+    private String dryyBstpNmixLwpr;
+
+    @JsonProperty("dryy_bstp_nmix_lwpr_date")
+    private String dryyBstpNmixLwprDate;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexOutput2Dto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisDailyIndexOutput2Dto.java
@@ -1,0 +1,53 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 캔들 차트 기준 사용 변수
+ * 날짜 + 시가 + 고가 + 저가 + 현재가
+ */
+@Getter
+@NoArgsConstructor
+public class KisDailyIndexOutput2Dto {
+
+    @JsonProperty("stck_bsop_date")
+    private String stckBsopDate; //주식 영업 일자
+
+    @JsonProperty("bstp_nmix_prpr")
+    private String bstpNmixPrpr; //업종 지수 현재가
+
+    @JsonProperty("prdy_vrss_sign")
+    private String prdyVrssSign;
+
+    @JsonProperty("bstp_nmix_prdy_vrss")
+    private String bstpNmixPrdyVrss;
+
+    @JsonProperty("bstp_nmix_prdy_ctrt")
+    private String bstpNmixPrdyCtrt;
+
+    @JsonProperty("bstp_nmix_oprc")
+    private String bstpNmixOprc; //지수 시가
+
+    @JsonProperty("bstp_nmix_hgpr")
+    private String bstpNmixHgpr; //최고가
+
+    @JsonProperty("bstp_nmix_lwpr")
+    private String bstpNmixLwpr; //최저가
+
+    @JsonProperty("acml_vol_rlim")
+    private String acmlVolRlim;
+
+    @JsonProperty("acml_vol")
+    private String acmlVol;
+
+    @JsonProperty("acml_tr_pbmn")
+    private String acmlTrPbmn;
+
+    @JsonProperty("invt_new_psdg")
+    private String invtNewPsdg;
+
+    @JsonProperty("d20_dsrt")
+    private String d20Dsrt;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisIndexApiResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisIndexApiResponseDto.java
@@ -1,0 +1,21 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KisIndexApiResponseDto {
+    @JsonProperty("rt_cd")
+    private String rtCd;   // 성공 실패 여부
+
+    @JsonProperty("msg_cd")
+    private String msgCd;  // 응답코드
+
+    @JsonProperty("msg1")
+    private String msg1;   // 응답메시지
+
+    @JsonProperty("output")
+    private KisIndexOutputDto output; // 응답상세
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisIndexOutputDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisIndexOutputDto.java
@@ -1,0 +1,117 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KisIndexOutputDto {
+    @JsonProperty("bstp_nmix_prpr")
+    private String bstpNmixPrpr;   // 업종 지수 현재가
+
+    @JsonProperty("bstp_nmix_prdy_vrss")
+    private String bstpNmixPrdyVrss;   // 업종 지수 전일 대비
+
+    @JsonProperty("prdy_vrss_sign")
+    private String prdyVrssSign;   // 전일 대비 부호
+
+    @JsonProperty("bstp_nmix_prdy_ctrt")
+    private String bstpNmixPrdyCtrt;   // 업종 지수 전일 대비율
+
+    @JsonProperty("acml_vol")
+    private String acmlVol;   // 누적 거래량
+
+    @JsonProperty("prdy_vol")
+    private String prdyVol;   // 전일 거래량
+
+    @JsonProperty("acml_tr_pbmn")
+    private String acmlTrPbmn;   // 누적 거래 대금
+
+    @JsonProperty("prdy_tr_pbmn")
+    private String prdyTrPbmn;   // 전일 거래 대금
+
+    @JsonProperty("bstp_nmix_oprc")
+    private String bstpNmixOprc;   // 업종 지수 시가
+
+    @JsonProperty("prdy_nmix_vrss_nmix_oprc")
+    private String prdyNmixVrssNmixOprc;   // 전일 지수 대비 지수 시가
+
+    @JsonProperty("oprc_vrss_prpr_sign")
+    private String oprcVrssPrprSign;   // 시가 대비 현재가 부호
+
+    @JsonProperty("bstp_nmix_oprc_prdy_ctrt")
+    private String bstpNmixOprcPrdyCtrt;   // 업종 지수 시가 전일 대비율
+
+    @JsonProperty("bstp_nmix_hgpr")
+    private String bstpNmixHgpr;   // 업종 지수 최고가
+
+    @JsonProperty("prdy_nmix_vrss_nmix_hgpr")
+    private String prdyNmixVrssNmixHgpr;   // 전일 지수 대비 지수 최고가
+
+    @JsonProperty("hgpr_vrss_prpr_sign")
+    private String hgprVrssPrprSign;   // 최고가 대비 현재가 부호
+
+    @JsonProperty("bstp_nmix_hgpr_prdy_ctrt")
+    private String bstpNmixHgprPrdyCtrt;   // 업종 지수 최고가 전일 대비율
+
+    @JsonProperty("bstp_nmix_lwpr")
+    private String bstpNmixLwpr;   // 업종 지수 최저가
+
+    @JsonProperty("prdy_clpr_vrss_lwpr")
+    private String prdyClprVrssLwpr;   // 전일 종가 대비 최저가
+
+    @JsonProperty("lwpr_vrss_prpr_sign")
+    private String lwprVrssPrprSign;   // 최저가 대비 현재가 부호
+
+    @JsonProperty("prdy_clpr_vrss_lwpr_rate")
+    private String prdyClprVrssLwprRate;   // 전일 종가 대비 최저가 비율
+
+    @JsonProperty("ascn_issu_cnt")
+    private String ascnIssuCnt;   // 상승 종목 수
+
+    @JsonProperty("uplm_issu_cnt")
+    private String uplmIssuCnt;   // 상한 종목 수
+
+    @JsonProperty("stnr_issu_cnt")
+    private String stnrIssuCnt;   // 보합 종목 수
+
+    @JsonProperty("down_issu_cnt")
+    private String downIssuCnt;   // 하락 종목 수
+
+    @JsonProperty("lslm_issu_cnt")
+    private String lslmIssuCnt;   // 하한 종목 수
+
+    @JsonProperty("dryy_bstp_nmix_hgpr")
+    private String dryyBstpNmixHgpr;   // 연중 업종지수 최고가
+
+    @JsonProperty("dryy_hgpr_vrss_prpr_rate")
+    private String dryyHgprVrssPrprRate;   // 연중 최고가 대비 현재가 비율
+
+    @JsonProperty("dryy_bstp_nmix_hgpr_date")
+    private String dryyBstpNmixHgprDate;   // 연중 업종지수 최고가 일자
+
+    @JsonProperty("dryy_bstp_nmix_lwpr")
+    private String dryyBstpNmixLwpr;   // 연중 업종지수 최저가
+
+    @JsonProperty("dryy_lwpr_vrss_prpr_rate")
+    private String dryyLwprVrssPrprRate;   // 연중 최저가 대비 현재가 비율
+
+    @JsonProperty("dryy_bstp_nmix_lwpr_date")
+    private String dryyBstpNmixLwprDate;   // 연중 업종지수 최저가 일자
+
+    @JsonProperty("total_askp_rsqn")
+    private String totalAskpRsqn;   // 총 매도호가 잔량
+
+    @JsonProperty("total_bidp_rsqn")
+    private String totalBidpRsqn;   // 총 매수호가 잔량
+
+    @JsonProperty("seln_rsqn_rate")
+    private String selnRsqnRate;   // 매도 잔량 비율
+
+    @JsonProperty("shnu_rsqn_rate")
+    private String shnuRsqnRate;   // 매수 잔량 비율
+
+    @JsonProperty("ntby_rsqn")
+    private String ntbyRsqn;   // 순매수 잔량
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisOverseasPriceDetailApiResponseDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisOverseasPriceDetailApiResponseDto.java
@@ -1,0 +1,19 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KisOverseasPriceDetailApiResponseDto {
+    @JsonProperty("rt_cd")
+    private String rtCd;
+    @JsonProperty("msg_cd")
+    private String msgCd;
+    @JsonProperty("msg1")
+    private String msg1;
+
+    @JsonProperty("output")
+    private KisOverseasPriceDetailOutputDto output;
+}

--- a/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisOverseasPriceDetailOutputDto.java
+++ b/src/main/java/com/financialinvestment/domain/stock/dto/hanto/KisOverseasPriceDetailOutputDto.java
@@ -1,0 +1,17 @@
+package com.financialinvestment.domain.stock.dto.hanto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KisOverseasPriceDetailOutputDto {
+
+    @JsonProperty("output")
+    private String curr;   // 통화
+    @JsonProperty("t_rate")
+    private String tRate;  // 당일환율
+    @JsonProperty("p_rate")
+    private String pRate;  // 전일환율
+}

--- a/src/main/java/com/financialinvestment/domain/stock/service/StockService.java
+++ b/src/main/java/com/financialinvestment/domain/stock/service/StockService.java
@@ -1,0 +1,158 @@
+package com.financialinvestment.domain.stock.service;
+
+import com.financialinvestment.domain.stock.dto.front.ExchangeRateResponseDto;
+import com.financialinvestment.domain.stock.dto.front.IndexDailyChartPointDto;
+import com.financialinvestment.domain.stock.dto.front.IndexSummaryResponseDto;
+import com.financialinvestment.domain.stock.dto.hanto.*;
+import com.financialinvestment.domain.util.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StockService {
+
+    private final KisMarketClient kisMarketClient;
+    private final KisAuthClient kisAuthClient;
+
+    /**
+     * 코스피와 코스닥의 일별 지수 값을 가져옴
+     *
+     */
+    public List<IndexSummaryResponseDto> getIndexSummaries() throws InterruptedException {
+        String accessToken = kisAuthClient.getAccessToken();
+
+        KisDailyIndexApiResponseDto kospiResponse = kisMarketClient.getDailyIndex(
+                accessToken,  "0001", "D", DateUtil.getTodayDateyyyyMMdd()
+        );
+
+        KisDailyIndexApiResponseDto kosdaqResponse = kisMarketClient.getDailyIndex(
+                accessToken,  "1001", "D", DateUtil.getTodayDateyyyyMMdd()
+        );
+
+        return List.of(
+                toIndexSummary(IndexType.KOSPI, "코스피", kospiResponse),
+                toIndexSummary(IndexType.KOSDAQ, "코스닥", kosdaqResponse)
+        );
+    }
+
+    private IndexSummaryResponseDto toIndexSummary(
+            IndexType indexType,
+            String name,
+            KisDailyIndexApiResponseDto response
+    ) {
+        KisDailyIndexOutput1Dto output1 = response.getOutput1();
+
+        //전일 대비 등락
+        BigDecimal change = toBigDecimal(output1.getBstpNmixPrdyVrss());
+
+        List<IndexDailyChartPointDto> chart = response.getOutput2().stream()
+                .sorted(Comparator.comparing(KisDailyIndexOutput2Dto::getStckBsopDate))
+                .map(output -> new IndexDailyChartPointDto(
+                        formatDate(output.getStckBsopDate()),
+                        toBigDecimal(output.getBstpNmixPrpr())
+                ))
+                .toList();
+        Direction direction = toDirection(output1.getPrdyVrssSign(), change);
+        return new IndexSummaryResponseDto(
+                toId(indexType),
+                name,
+                toBigDecimal(output1.getBstpNmixPrpr()),
+                change,
+                toBigDecimal(output1.getBstpNmixPrdyCtrt()),
+                direction,
+                OffsetDateTime.now(),
+                toChartColor(direction),
+                chart
+        );
+    }
+    public List<IndexSummaryResponseDto> getExchangeRateSummary() throws InterruptedException {
+        String accessToken = kisAuthClient.getAccessToken();
+
+        KisOverseasPriceDetailApiResponseDto response = kisMarketClient.getOverseasPriceDetail(accessToken, "NAS", "QQQ");
+        KisOverseasPriceDetailOutputDto output = response.getOutput();
+
+        BigDecimal current = toBigDecimal(output.getTRate());
+        BigDecimal previous = toBigDecimal(output.getPRate());
+        BigDecimal change = current.subtract(previous);
+
+        BigDecimal changeRate = previous.compareTo(BigDecimal.ZERO) == 0
+                ? BigDecimal.ZERO
+                : change.divide(previous, 6, RoundingMode.HALF_UP)
+                  .multiply(BigDecimal.valueOf(100));
+
+        Direction direction = compareDirection(change);
+
+        return List.of(new IndexSummaryResponseDto(
+                "usdKrw",
+                "원/달러",
+                current,
+                change,
+                changeRate,
+                direction,
+                OffsetDateTime.now(),
+                toChartColor(direction),
+                List.of()
+        ));
+    }
+
+    private String toId(IndexType indexType) {
+        return indexType.name().toLowerCase();
+    }
+
+    private String formatDate(String value) {
+        return LocalDate.parse(value, DateTimeFormatter.BASIC_ISO_DATE)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+
+    private BigDecimal toBigDecimal(String value) {
+        if (value == null || value.isBlank()) {
+            return BigDecimal.ZERO;
+        }
+        return new BigDecimal(value.trim());
+    }
+
+    private Direction toDirection(String sign, BigDecimal change) {
+        if (sign == null || sign.isBlank()) {
+            return compareDirection(change);
+        }
+
+        return switch (sign.trim()) {
+            case "1", "2" -> Direction.UP;
+            case "4", "5" -> Direction.DOWN;
+            case "3" -> Direction.SAME;
+            default -> compareDirection(change);
+        };
+    }
+
+    private Direction compareDirection(BigDecimal change) {
+        int compare = change.compareTo(BigDecimal.ZERO);
+        if (compare > 0) {
+            return Direction.UP;
+        }
+        if (compare < 0) {
+            return Direction.DOWN;
+        }
+        return Direction.SAME;
+    }
+
+    private String toChartColor(Direction direction) {
+        return switch (direction) {
+            case UP -> "#006e1c";
+            case DOWN -> "#ba1a1a";
+            case SAME -> "#6f6f6f";
+        };
+    }
+
+}

--- a/src/main/java/com/financialinvestment/domain/util/ApiResponse.java
+++ b/src/main/java/com/financialinvestment/domain/util/ApiResponse.java
@@ -1,0 +1,17 @@
+package com.financialinvestment.domain.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private int code;
+    private String message;
+    private T result;
+
+    public static <T> ApiResponse<T> success(String message, T result){
+        return new ApiResponse<>(200, message,result);
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/util/DateUtil.java
+++ b/src/main/java/com/financialinvestment/domain/util/DateUtil.java
@@ -1,0 +1,13 @@
+package com.financialinvestment.domain.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+
+    public static String getTodayDateyyyyMMdd(){
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter formatter  = DateTimeFormatter.ofPattern("yyyyMMdd");
+        return today.format(formatter);
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/util/Direction.java
+++ b/src/main/java/com/financialinvestment/domain/util/Direction.java
@@ -1,0 +1,7 @@
+package com.financialinvestment.domain.util;
+
+public enum Direction {
+    UP,
+    DOWN,
+    SAME
+}

--- a/src/main/java/com/financialinvestment/domain/util/IndexType.java
+++ b/src/main/java/com/financialinvestment/domain/util/IndexType.java
@@ -1,0 +1,6 @@
+package com.financialinvestment.domain.util;
+
+public enum IndexType {
+    KOSPI,
+    KOSDAQ
+}

--- a/src/main/java/com/financialinvestment/domain/util/KisAuthClient.java
+++ b/src/main/java/com/financialinvestment/domain/util/KisAuthClient.java
@@ -1,0 +1,68 @@
+package com.financialinvestment.domain.util;
+
+import com.financialinvestment.domain.stock.dto.hanto.KisAccessTokenRequestDto;
+import com.financialinvestment.domain.stock.dto.hanto.KisAccessTokenResponseDto;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class KisAuthClient {
+
+    private final RestClient kisRestClient;
+
+    @Value("${kis.app-key}")
+    private String appKey;
+
+    @Value("${kis.app-secret}")
+    private String appSecret;
+
+    private String accessToken;
+    private LocalDateTime accessTokenExpiredAt;
+
+    public synchronized String getAccessToken() {
+        if (isValidToken()) {
+            return accessToken;
+        }
+
+        KisAccessTokenRequestDto request = new KisAccessTokenRequestDto(
+                "client_credentials",
+                appKey,
+                appSecret
+        );
+
+        KisAccessTokenResponseDto response = kisRestClient.post()
+                .uri("/oauth2/tokenP")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(KisAccessTokenResponseDto.class);
+
+        if (response == null || response.getAccessToken() == null) {
+            throw new IllegalStateException("한투 access token 발급 실패");
+        }
+
+        this.accessToken = response.getAccessToken();
+        this.accessTokenExpiredAt = parseExpiredAt(response.getTokenExpired());
+
+        return this.accessToken;
+    }
+
+    private boolean isValidToken() {
+        return accessToken != null
+                && accessTokenExpiredAt != null
+                && LocalDateTime.now().isBefore(accessTokenExpiredAt.minusMinutes(5));
+    }
+
+    private LocalDateTime parseExpiredAt(String expiredAt) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return LocalDateTime.parse(expiredAt, formatter);
+    }
+}

--- a/src/main/java/com/financialinvestment/domain/util/KisMarketClient.java
+++ b/src/main/java/com/financialinvestment/domain/util/KisMarketClient.java
@@ -1,0 +1,95 @@
+package com.financialinvestment.domain.util;
+
+import com.financialinvestment.domain.stock.dto.hanto.KisDailyIndexApiResponseDto;
+import com.financialinvestment.domain.stock.dto.hanto.KisIndexApiResponseDto;
+import com.financialinvestment.domain.stock.dto.hanto.KisOverseasPriceDetailApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KisMarketClient {
+
+    private final RestClient kisRestClient;
+
+    @Value("${kis.app-key}")
+    private String appKey;
+
+    @Value("${kis.app-secret}")
+    private String appSecret;
+
+    /**
+     * 국내 업종(코스피, 코스닥) 현재가
+     * -> 차트를 그리기엔 맞지 않음.
+     *
+     * 주의점 : 장중이 아닐때는 등락이 0으로 표시된다.
+     */
+    public KisIndexApiResponseDto getCurrentIndex(String accessToken, String marketType) throws InterruptedException {
+        Thread.sleep(1000);
+        return kisRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-index-price")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "U")
+                        .queryParam("FID_INPUT_ISCD", marketType)
+                        .build())
+                .header("content-type", MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHPUP02100000")
+                .header("custtype","P")
+                .retrieve()
+                .body(KisIndexApiResponseDto.class);
+    }
+
+    /**
+     * 국내 업종 일자별 가격
+     *
+     */
+    public KisDailyIndexApiResponseDto getDailyIndex(String accessToken, String marketType, String period, String date) throws InterruptedException {
+        Thread.sleep(1000);
+        return kisRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-index-daily-price")
+                        .queryParam("FID_PERIOD_DIV_CODE", period)
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "U")
+                        .queryParam("FID_INPUT_ISCD", marketType)
+                        .queryParam("FID_INPUT_DATE_1", date)
+                        .build())
+                .header("content-type", MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHPUP02120000")
+                .header("custtype","P")
+                .retrieve()
+                .body(KisDailyIndexApiResponseDto.class);
+    }
+
+    public KisOverseasPriceDetailApiResponseDto getOverseasPriceDetail(
+            String accessToken,
+            String exchangeCode,
+            String symbol
+    ) throws InterruptedException {
+        Thread.sleep(1000);
+        return kisRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/overseas-price/v1/quotations/price-detail")
+                        .queryParam("AUTH", "")
+                        .queryParam("EXCD", exchangeCode)
+                        .queryParam("SYMB", symbol)
+                        .build())
+                .header("content-type", MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "HHDFS76200200")
+                .header("custtype", "P")
+                .retrieve()
+                .body(KisOverseasPriceDetailApiResponseDto.class);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=financial-Investment
+
+kis.app-key= ${KIS_APP_KEY}
+kis.app-secret= ${KIS_APP_SECRET}
+
+logging.level.com.financialinvestment=DEBUG


### PR DESCRIPTION
## 개발된 기능
- 한투 API AccessToken 발급 -> 주식 데이터 요청시 사용
- StockController에서 대시보드 용 코스피, 코스닥, 환율 데이터 가져와서 프론트에 응답
- 한투 API응답 데이터 서비스에서 전처리 후 프론트로 전달

## 알아둘 점
- 한투API는 초당 요청제한이 있는듯 보여 각 요청마다 1초를 sleep
- 이후에 변경 필요